### PR TITLE
fix: APIキー保存時にバリデーションを追加 (#1)

### DIFF
--- a/jobmemory-ai/includes/class-admin.php
+++ b/jobmemory-ai/includes/class-admin.php
@@ -1,365 +1,413 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class JMAI_Admin {
 
-    public function __construct() {
-        add_action( 'admin_menu', [ $this, 'add_menu' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-        add_action( 'wp_ajax_jmai_generate_job', [ $this, 'ajax_generate_job' ] );
-        add_action( 'wp_ajax_jmai_save_feedback', [ $this, 'ajax_save_feedback' ] );
-        add_action( 'wp_ajax_jmai_save_job', [ $this, 'ajax_save_job' ] );
-        add_action( 'wp_ajax_jmai_reset_memory', [ $this, 'ajax_reset_memory' ] );
-    }
+	private const ALLOWED_PATTERNS = array( 'a', 'b', 'c' );
 
-    public function add_menu(): void {
-        add_menu_page(
-            'JobMemory AI',
-            'JobMemory AI',
-            'manage_options',
-            'jobmemory-ai',
-            [ $this, 'render_generate_page' ],
-            'dashicons-format-aside',
-            30
-        );
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'add_menu' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'wp_ajax_jmai_generate_job', array( $this, 'ajax_generate_job' ) );
+		add_action( 'wp_ajax_jmai_save_feedback', array( $this, 'ajax_save_feedback' ) );
+		add_action( 'wp_ajax_jmai_save_job', array( $this, 'ajax_save_job' ) );
+		add_action( 'wp_ajax_jmai_reset_memory', array( $this, 'ajax_reset_memory' ) );
+	}
 
-        add_submenu_page(
-            'jobmemory-ai',
-            '求人生成',
-            '求人生成',
-            'manage_options',
-            'jobmemory-ai',
-            [ $this, 'render_generate_page' ]
-        );
+	public function add_menu(): void {
+		add_menu_page(
+			'JobMemory AI',
+			'JobMemory AI',
+			'manage_options',
+			'jobmemory-ai',
+			array( $this, 'render_generate_page' ),
+			'dashicons-format-aside',
+			30
+		);
 
-        add_submenu_page(
-            'jobmemory-ai',
-            '設定',
-            '設定',
-            'manage_options',
-            'jobmemory-ai-settings',
-            [ $this, 'render_settings_page' ]
-        );
+		add_submenu_page(
+			'jobmemory-ai',
+			esc_html__( '求人生成', 'jobmemory-ai' ),
+			esc_html__( '求人生成', 'jobmemory-ai' ),
+			'manage_options',
+			'jobmemory-ai',
+			array( $this, 'render_generate_page' )
+		);
 
-        add_submenu_page(
-            'jobmemory-ai',
-            'Memory確認',
-            'Memory確認',
-            'manage_options',
-            'jobmemory-ai-memory',
-            [ $this, 'render_memory_page' ]
-        );
-    }
+		add_submenu_page(
+			'jobmemory-ai',
+			esc_html__( '設定', 'jobmemory-ai' ),
+			esc_html__( '設定', 'jobmemory-ai' ),
+			'manage_options',
+			'jobmemory-ai-settings',
+			array( $this, 'render_settings_page' )
+		);
 
-    public function enqueue_assets( string $hook ): void {
-        if ( strpos( $hook, 'jobmemory-ai' ) === false ) {
-            return;
-        }
+		add_submenu_page(
+			'jobmemory-ai',
+			esc_html__( 'Memory確認', 'jobmemory-ai' ),
+			esc_html__( 'Memory確認', 'jobmemory-ai' ),
+			'manage_options',
+			'jobmemory-ai-memory',
+			array( $this, 'render_memory_page' )
+		);
+	}
 
-        wp_enqueue_style(
-            'jmai-admin',
-            JMAI_PLUGIN_URL . 'assets/admin.css',
-            [],
-            JMAI_VERSION
-        );
+	public function enqueue_assets( string $hook ): void {
+		if ( false === strpos( $hook, 'jobmemory-ai' ) ) {
+			return;
+		}
 
-        wp_enqueue_script(
-            'jmai-admin',
-            JMAI_PLUGIN_URL . 'assets/admin.js',
-            [ 'jquery' ],
-            JMAI_VERSION,
-            true
-        );
+		wp_enqueue_style(
+			'jmai-admin',
+			JMAI_PLUGIN_URL . 'assets/admin.css',
+			array(),
+			JMAI_VERSION
+		);
 
-        wp_localize_script( 'jmai-admin', 'jmai', [
-            'ajax_url' => admin_url( 'admin-ajax.php' ),
-            'nonce'    => wp_create_nonce( 'jmai_nonce' ),
-        ] );
-    }
+		wp_enqueue_script(
+			'jmai-admin',
+			JMAI_PLUGIN_URL . 'assets/admin.js',
+			array( 'jquery' ),
+			JMAI_VERSION,
+			true
+		);
 
-    /* ─── 求人生成画面 ─── */
+		wp_localize_script(
+			'jmai-admin',
+			'jmai',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'jmai_nonce' ),
+			)
+		);
+	}
 
-    public function render_generate_page(): void {
-        $api_key = get_option( 'jmai_openai_api_key', '' );
-        ?>
-        <div class="wrap jmai-wrap">
-            <h1>JobMemory AI - 求人生成</h1>
-            <p class="jmai-description">GAIS会員企業向けAI求人生成ツール</p>
+	/* ─── 求人生成画面 ─── */
 
-            <?php if ( empty( $api_key ) ) : ?>
-                <div class="notice notice-warning">
-                    <p>OpenAI APIキーが未設定です。<a href="<?php echo esc_url( admin_url( 'admin.php?page=jobmemory-ai-settings' ) ); ?>">設定画面</a>でAPIキーを入力してください。</p>
-                </div>
-            <?php endif; ?>
+	public function render_generate_page(): void {
+		$api_key = get_option( 'jmai_openai_api_key', '' );
+		?>
+		<div class="wrap jmai-wrap">
+			<h1><?php esc_html_e( 'JobMemory AI - 求人生成', 'jobmemory-ai' ); ?></h1>
+			<p class="jmai-description"><?php esc_html_e( 'GAIS会員企業向けAI求人生成ツール', 'jobmemory-ai' ); ?></p>
 
-            <form id="jmai-generate-form">
-                <div class="jmai-card">
-                    <h2>基本情報</h2>
-                    <table class="form-table">
-                        <tr>
-                            <th><label for="job_title">職種名 <span class="jmai-required">*</span></label></th>
-                            <td><input type="text" id="job_title" name="job_title" class="regular-text" placeholder="例：AIエンジニア、プロンプトエンジニア" required /></td>
-                        </tr>
-                    </table>
-                </div>
+			<?php if ( empty( $api_key ) ) : ?>
+				<div class="notice notice-warning">
+					<p>
+						<?php
+						printf(
+							/* translators: %s: settings page link */
+							esc_html__( 'OpenAI APIキーが未設定です。%sでAPIキーを入力してください。', 'jobmemory-ai' ),
+							'<a href="' . esc_url( admin_url( 'admin.php?page=jobmemory-ai-settings' ) ) . '">' . esc_html__( '設定画面', 'jobmemory-ai' ) . '</a>'
+						);
+						?>
+					</p>
+				</div>
+			<?php endif; ?>
 
-                <div class="jmai-card">
-                    <h2>自社の魅力・優位性</h2>
-                    <p class="description">入力するほど良い求人文が生成されます</p>
-                    <table class="form-table">
-                        <tr>
-                            <th><label for="recruitment_background">募集背景</label></th>
-                            <td><textarea id="recruitment_background" name="recruitment_background" class="large-text" rows="2" placeholder="例：事業拡大のため、新規プロジェクト立ち上げのため"></textarea></td>
-                        </tr>
-                        <tr>
-                            <th><label for="job_description">仕事内容の補足</label></th>
-                            <td><textarea id="job_description" name="job_description" class="large-text" rows="2" placeholder="例：LLMを活用した社内ツール開発"></textarea></td>
-                        </tr>
-                        <tr>
-                            <th><label for="company_strengths">自社の強み・魅力</label></th>
-                            <td><textarea id="company_strengths" name="company_strengths" class="large-text" rows="2" placeholder="例：リモートワーク可、フレックス制度、AI研修充実"></textarea></td>
-                        </tr>
-                        <tr>
-                            <th><label for="work_culture">職場環境・カルチャー</label></th>
-                            <td><textarea id="work_culture" name="work_culture" class="large-text" rows="2" placeholder="例：少人数チーム、フラットな組織、挑戦を歓迎"></textarea></td>
-                        </tr>
-                        <tr>
-                            <th><label for="salary_benefits">給与・待遇</label></th>
-                            <td><textarea id="salary_benefits" name="salary_benefits" class="large-text" rows="2" placeholder="例：年収500-800万円、書籍購入補助あり"></textarea></td>
-                        </tr>
-                        <tr>
-                            <th><label for="ideal_candidate">求める人物像</label></th>
-                            <td><textarea id="ideal_candidate" name="ideal_candidate" class="large-text" rows="2" placeholder="例：自走できる方、新しい技術に興味がある方"></textarea></td>
-                        </tr>
-                    </table>
-                </div>
+			<form id="jmai-generate-form">
+				<div class="jmai-card">
+					<h2><?php esc_html_e( '基本情報', 'jobmemory-ai' ); ?></h2>
+					<table class="form-table">
+						<tr>
+							<th><label for="job_title"><?php esc_html_e( '職種名', 'jobmemory-ai' ); ?> <span class="jmai-required">*</span></label></th>
+							<td><input type="text" id="job_title" name="job_title" class="regular-text" placeholder="<?php esc_attr_e( '例：AIエンジニア、プロンプトエンジニア', 'jobmemory-ai' ); ?>" required /></td>
+						</tr>
+					</table>
+				</div>
 
-                <p>
-                    <button type="submit" class="button button-primary button-hero" id="jmai-generate-btn">AIで求人文を生成（3パターン）</button>
-                </p>
-            </form>
+				<div class="jmai-card">
+					<h2><?php esc_html_e( '自社の魅力・優位性', 'jobmemory-ai' ); ?></h2>
+					<p class="description"><?php esc_html_e( '入力するほど良い求人文が生成されます', 'jobmemory-ai' ); ?></p>
+					<table class="form-table">
+						<tr>
+							<th><label for="recruitment_background"><?php esc_html_e( '募集背景', 'jobmemory-ai' ); ?></label></th>
+							<td><textarea id="recruitment_background" name="recruitment_background" class="large-text" rows="2" placeholder="<?php esc_attr_e( '例：事業拡大のため、新規プロジェクト立ち上げのため', 'jobmemory-ai' ); ?>"></textarea></td>
+						</tr>
+						<tr>
+							<th><label for="job_description"><?php esc_html_e( '仕事内容の補足', 'jobmemory-ai' ); ?></label></th>
+							<td><textarea id="job_description" name="job_description" class="large-text" rows="2" placeholder="<?php esc_attr_e( '例：LLMを活用した社内ツール開発', 'jobmemory-ai' ); ?>"></textarea></td>
+						</tr>
+						<tr>
+							<th><label for="company_strengths"><?php esc_html_e( '自社の強み・魅力', 'jobmemory-ai' ); ?></label></th>
+							<td><textarea id="company_strengths" name="company_strengths" class="large-text" rows="2" placeholder="<?php esc_attr_e( '例：リモートワーク可、フレックス制度、AI研修充実', 'jobmemory-ai' ); ?>"></textarea></td>
+						</tr>
+						<tr>
+							<th><label for="work_culture"><?php esc_html_e( '職場環境・カルチャー', 'jobmemory-ai' ); ?></label></th>
+							<td><textarea id="work_culture" name="work_culture" class="large-text" rows="2" placeholder="<?php esc_attr_e( '例：少人数チーム、フラットな組織、挑戦を歓迎', 'jobmemory-ai' ); ?>"></textarea></td>
+						</tr>
+						<tr>
+							<th><label for="salary_benefits"><?php esc_html_e( '給与・待遇', 'jobmemory-ai' ); ?></label></th>
+							<td><textarea id="salary_benefits" name="salary_benefits" class="large-text" rows="2" placeholder="<?php esc_attr_e( '例：年収500-800万円、書籍購入補助あり', 'jobmemory-ai' ); ?>"></textarea></td>
+						</tr>
+						<tr>
+							<th><label for="ideal_candidate"><?php esc_html_e( '求める人物像', 'jobmemory-ai' ); ?></label></th>
+							<td><textarea id="ideal_candidate" name="ideal_candidate" class="large-text" rows="2" placeholder="<?php esc_attr_e( '例：自走できる方、新しい技術に興味がある方', 'jobmemory-ai' ); ?>"></textarea></td>
+						</tr>
+					</table>
+				</div>
 
-            <div id="jmai-loading" style="display:none;">
-                <div class="jmai-loading-spinner">
-                    <span class="spinner is-active"></span>
-                    <span>3パターン生成中...（約30秒）</span>
-                </div>
-            </div>
+				<p>
+					<button type="submit" class="button button-primary button-hero" id="jmai-generate-btn"><?php esc_html_e( 'AIで求人文を生成（3パターン）', 'jobmemory-ai' ); ?></button>
+				</p>
+			</form>
 
-            <div id="jmai-result-area" style="display:none;">
-                <div class="jmai-card">
-                    <h2>生成結果</h2>
+			<div id="jmai-loading" style="display:none;">
+				<div class="jmai-loading-spinner">
+					<span class="spinner is-active"></span>
+					<span><?php esc_html_e( '3パターン生成中...（約30秒）', 'jobmemory-ai' ); ?></span>
+				</div>
+			</div>
 
-                    <div class="jmai-tabs">
-                        <button class="jmai-tab active" data-pattern="a">パターンA<br><small>スタンダード</small></button>
-                        <button class="jmai-tab" data-pattern="b">パターンB<br><small>挑戦的</small></button>
-                        <button class="jmai-tab" data-pattern="c">パターンC<br><small>カジュアル</small></button>
-                    </div>
+			<div id="jmai-result-area" style="display:none;">
+				<div class="jmai-card">
+					<h2><?php esc_html_e( '生成結果', 'jobmemory-ai' ); ?></h2>
 
-                    <div class="jmai-tab-content" id="pattern_a"></div>
-                    <div class="jmai-tab-content" id="pattern_b" style="display:none;"></div>
-                    <div class="jmai-tab-content" id="pattern_c" style="display:none;"></div>
-                </div>
+					<div class="jmai-tabs">
+						<button class="jmai-tab active" data-pattern="a"><?php esc_html_e( 'パターンA', 'jobmemory-ai' ); ?><br><small><?php esc_html_e( 'スタンダード', 'jobmemory-ai' ); ?></small></button>
+						<button class="jmai-tab" data-pattern="b"><?php esc_html_e( 'パターンB', 'jobmemory-ai' ); ?><br><small><?php esc_html_e( '挑戦的', 'jobmemory-ai' ); ?></small></button>
+						<button class="jmai-tab" data-pattern="c"><?php esc_html_e( 'パターンC', 'jobmemory-ai' ); ?><br><small><?php esc_html_e( 'カジュアル', 'jobmemory-ai' ); ?></small></button>
+					</div>
 
-                <div class="jmai-card">
-                    <h2>フィードバック（任意）</h2>
-                    <p class="description">改善点を入力するとMemoryに蓄積され、次回以降の生成に反映されます</p>
-                    <textarea id="jmai-feedback" class="large-text" rows="3" placeholder="この求人文の改善点があれば入力してください"></textarea>
+					<div class="jmai-tab-content" id="pattern_a"></div>
+					<div class="jmai-tab-content" id="pattern_b" style="display:none;"></div>
+					<div class="jmai-tab-content" id="pattern_c" style="display:none;"></div>
+				</div>
 
-                    <div class="jmai-actions">
-                        <button type="button" class="button" id="jmai-save-feedback-btn">フィードバックを保存</button>
-                        <button type="button" class="button button-primary" id="jmai-save-job-btn">Simple Job Boardに下書き保存</button>
-                    </div>
-                </div>
-            </div>
+				<div class="jmai-card">
+					<h2><?php esc_html_e( 'フィードバック（任意）', 'jobmemory-ai' ); ?></h2>
+					<p class="description"><?php esc_html_e( '改善点を入力するとMemoryに蓄積され、次回以降の生成に反映されます', 'jobmemory-ai' ); ?></p>
+					<textarea id="jmai-feedback" class="large-text" rows="3" placeholder="<?php esc_attr_e( 'この求人文の改善点があれば入力してください', 'jobmemory-ai' ); ?>"></textarea>
 
-            <div id="jmai-notices"></div>
-        </div>
-        <?php
-    }
+					<div class="jmai-actions">
+						<button type="button" class="button" id="jmai-save-feedback-btn"><?php esc_html_e( 'フィードバックを保存', 'jobmemory-ai' ); ?></button>
+						<button type="button" class="button button-primary" id="jmai-save-job-btn"><?php esc_html_e( 'Simple Job Boardに下書き保存', 'jobmemory-ai' ); ?></button>
+					</div>
+				</div>
+			</div>
 
-    /* ─── 設定画面 ─── */
+			<div id="jmai-notices"></div>
+		</div>
+		<?php
+	}
 
-    public function render_settings_page(): void {
-        if ( isset( $_POST['jmai_save_settings'] ) && check_admin_referer( 'jmai_settings' ) ) {
-            $api_key = sanitize_text_field( wp_unslash( $_POST['jmai_openai_api_key'] ?? '' ) );
-            update_option( 'jmai_openai_api_key', $api_key );
-            echo '<div class="notice notice-success"><p>設定を保存しました。</p></div>';
-        }
+	/* ─── 設定画面 ─── */
 
-        $api_key = get_option( 'jmai_openai_api_key', '' );
-        ?>
-        <div class="wrap jmai-wrap">
-            <h1>JobMemory AI - 設定</h1>
-            <form method="post">
-                <?php wp_nonce_field( 'jmai_settings' ); ?>
-                <div class="jmai-card">
-                    <table class="form-table">
-                        <tr>
-                            <th><label for="jmai_openai_api_key">OpenAI APIキー</label></th>
-                            <td>
-                                <input type="password" id="jmai_openai_api_key" name="jmai_openai_api_key" class="regular-text" value="<?php echo esc_attr( $api_key ); ?>" />
-                                <p class="description">OpenAIのAPIキーを入力してください。<a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">APIキーの取得はこちら</a></p>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-                <p>
-                    <button type="submit" name="jmai_save_settings" class="button button-primary">設定を保存</button>
-                </p>
-            </form>
-        </div>
-        <?php
-    }
+	public function render_settings_page(): void {
+		if ( isset( $_POST['jmai_save_settings'] )
+			&& current_user_can( 'manage_options' )
+			&& check_admin_referer( 'jmai_settings' )
+		) {
+			$api_key = sanitize_text_field( wp_unslash( $_POST['jmai_openai_api_key'] ?? '' ) );
 
-    /* ─── Memory確認画面 ─── */
+			if ( JMAI_AI_Client::validate_api_key( $api_key ) ) {
+				update_option( 'jmai_openai_api_key', $api_key );
+				echo '<div class="notice notice-info"><p style="color:#0073aa;font-weight:bold;">'
+					. esc_html__( '登録成功', 'jobmemory-ai' )
+					. '</p></div>';
+			} else {
+				echo '<div class="notice notice-error"><p style="color:#d63638;font-weight:bold;">'
+					. esc_html__( '登録失敗', 'jobmemory-ai' )
+					. '</p></div>';
+			}
+		}
 
-    public function render_memory_page(): void {
-        $memory = ( new JMAI_Memory() )->get();
-        ?>
-        <div class="wrap jmai-wrap">
-            <h1>JobMemory AI - Memory確認</h1>
-            <p class="jmai-description">GAISの共通知見と、蓄積されたフィードバック履歴を確認できます。</p>
+		$api_key = get_option( 'jmai_openai_api_key', '' );
+		?>
+		<div class="wrap jmai-wrap">
+			<h1><?php esc_html_e( 'JobMemory AI - 設定', 'jobmemory-ai' ); ?></h1>
+			<form method="post">
+				<?php wp_nonce_field( 'jmai_settings' ); ?>
+				<div class="jmai-card">
+					<table class="form-table">
+						<tr>
+							<th><label for="jmai_openai_api_key"><?php esc_html_e( 'OpenAI APIキー', 'jobmemory-ai' ); ?></label></th>
+							<td>
+								<input type="password" id="jmai_openai_api_key" name="jmai_openai_api_key" class="regular-text" value="<?php echo esc_attr( $api_key ); ?>" />
+								<p class="description">
+									<?php
+									printf(
+										/* translators: %s: OpenAI API keys URL */
+										esc_html__( 'OpenAIのAPIキーを入力してください。%s', 'jobmemory-ai' ),
+										'<a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">' . esc_html__( 'APIキーの取得はこちら', 'jobmemory-ai' ) . '</a>'
+									);
+									?>
+								</p>
+							</td>
+						</tr>
+					</table>
+				</div>
+				<p>
+					<button type="submit" name="jmai_save_settings" class="button button-primary"><?php esc_html_e( '設定を保存', 'jobmemory-ai' ); ?></button>
+				</p>
+			</form>
+		</div>
+		<?php
+	}
 
-            <div class="jmai-card">
-                <h2>現在のMemory</h2>
-                <textarea class="large-text jmai-memory-display" rows="20" readonly><?php echo esc_textarea( $memory ); ?></textarea>
-            </div>
+	/* ─── Memory確認画面 ─── */
 
-            <p>
-                <button type="button" class="button button-secondary" id="jmai-reset-memory-btn">Memoryをリセット</button>
-                <span class="description">※ リセットするとフィードバック履歴が削除され、初期状態に戻ります。</span>
-            </p>
-        </div>
-        <?php
-    }
+	public function render_memory_page(): void {
+		$memory = ( new JMAI_Memory() )->get();
+		?>
+		<div class="wrap jmai-wrap">
+			<h1><?php esc_html_e( 'JobMemory AI - Memory確認', 'jobmemory-ai' ); ?></h1>
+			<p class="jmai-description"><?php esc_html_e( 'GAISの共通知見と、蓄積されたフィードバック履歴を確認できます。', 'jobmemory-ai' ); ?></p>
 
-    /* ─── AJAX: 求人文生成 ─── */
+			<div class="jmai-card">
+				<h2><?php esc_html_e( '現在のMemory', 'jobmemory-ai' ); ?></h2>
+				<textarea class="large-text jmai-memory-display" rows="20" readonly><?php echo esc_textarea( $memory ); ?></textarea>
+			</div>
 
-    public function ajax_generate_job(): void {
-        check_ajax_referer( 'jmai_nonce', 'nonce' );
+			<p>
+				<button type="button" class="button button-secondary" id="jmai-reset-memory-btn"><?php esc_html_e( 'Memoryをリセット', 'jobmemory-ai' ); ?></button>
+				<span class="description"><?php esc_html_e( '※ リセットするとフィードバック履歴が削除され、初期状態に戻ります。', 'jobmemory-ai' ); ?></span>
+			</p>
+		</div>
+		<?php
+	}
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => '権限がありません。' ] );
-        }
+	/* ─── AJAX: 求人文生成 ─── */
 
-        $job_title = sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) );
-        if ( empty( $job_title ) ) {
-            wp_send_json_error( [ 'message' => '職種名を入力してください。' ] );
-        }
+	public function ajax_generate_job(): void {
+		check_ajax_referer( 'jmai_nonce', 'nonce' );
 
-        $params = [
-            'job_title'              => $job_title,
-            'recruitment_background' => sanitize_textarea_field( wp_unslash( $_POST['recruitment_background'] ?? '' ) ),
-            'job_description'        => sanitize_textarea_field( wp_unslash( $_POST['job_description'] ?? '' ) ),
-            'company_strengths'      => sanitize_textarea_field( wp_unslash( $_POST['company_strengths'] ?? '' ) ),
-            'work_culture'           => sanitize_textarea_field( wp_unslash( $_POST['work_culture'] ?? '' ) ),
-            'salary_benefits'        => sanitize_textarea_field( wp_unslash( $_POST['salary_benefits'] ?? '' ) ),
-            'ideal_candidate'        => sanitize_textarea_field( wp_unslash( $_POST['ideal_candidate'] ?? '' ) ),
-        ];
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( '権限がありません。', 'jobmemory-ai' ) ) );
+		}
 
-        $client = new JMAI_AI_Client();
-        $result = $client->generate( $params );
+		$job_title = sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) );
+		if ( empty( $job_title ) ) {
+			wp_send_json_error( array( 'message' => __( '職種名を入力してください。', 'jobmemory-ai' ) ) );
+		}
 
-        if ( ! $result['success'] ) {
-            wp_send_json_error( [ 'message' => $result['error'] ] );
-        }
+		$params = array(
+			'job_title'              => $job_title,
+			'recruitment_background' => sanitize_textarea_field( wp_unslash( $_POST['recruitment_background'] ?? '' ) ),
+			'job_description'        => sanitize_textarea_field( wp_unslash( $_POST['job_description'] ?? '' ) ),
+			'company_strengths'      => sanitize_textarea_field( wp_unslash( $_POST['company_strengths'] ?? '' ) ),
+			'work_culture'           => sanitize_textarea_field( wp_unslash( $_POST['work_culture'] ?? '' ) ),
+			'salary_benefits'        => sanitize_textarea_field( wp_unslash( $_POST['salary_benefits'] ?? '' ) ),
+			'ideal_candidate'        => sanitize_textarea_field( wp_unslash( $_POST['ideal_candidate'] ?? '' ) ),
+		);
 
-        wp_send_json_success( [
-            'pattern_a' => $result['pattern_a'],
-            'pattern_b' => $result['pattern_b'],
-            'pattern_c' => $result['pattern_c'],
-            'job_title' => $job_title,
-        ] );
-    }
+		$client = new JMAI_AI_Client();
+		$result = $client->generate( $params );
 
-    /* ─── AJAX: フィードバック保存 ─── */
+		if ( ! $result['success'] ) {
+			wp_send_json_error( array( 'message' => $result['error'] ) );
+		}
 
-    public function ajax_save_feedback(): void {
-        check_ajax_referer( 'jmai_nonce', 'nonce' );
+		wp_send_json_success(
+			array(
+				'pattern_a' => $result['pattern_a'],
+				'pattern_b' => $result['pattern_b'],
+				'pattern_c' => $result['pattern_c'],
+				'job_title' => $job_title,
+			)
+		);
+	}
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => '権限がありません。' ] );
-        }
+	/* ─── AJAX: フィードバック保存 ─── */
 
-        $feedback         = sanitize_textarea_field( wp_unslash( $_POST['feedback'] ?? '' ) );
-        $job_title        = sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) );
-        $selected_pattern = sanitize_text_field( wp_unslash( $_POST['selected_pattern'] ?? '' ) );
+	public function ajax_save_feedback(): void {
+		check_ajax_referer( 'jmai_nonce', 'nonce' );
 
-        if ( empty( $feedback ) ) {
-            wp_send_json_error( [ 'message' => 'フィードバックを入力してください。' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( '権限がありません。', 'jobmemory-ai' ) ) );
+		}
 
-        $pattern_labels = [
-            'a' => 'スタンダード',
-            'b' => '挑戦的',
-            'c' => 'カジュアル',
-        ];
-        $label = $pattern_labels[ $selected_pattern ] ?? $selected_pattern;
-        $date  = wp_date( 'Y-m-d H:i' );
+		$feedback         = sanitize_textarea_field( wp_unslash( $_POST['feedback'] ?? '' ) );
+		$job_title        = sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) );
+		$selected_pattern = sanitize_text_field( wp_unslash( $_POST['selected_pattern'] ?? '' ) );
 
-        $entry = "\n[{$date}] 職種: {$job_title} / パターン: {$label}\nフィードバック: {$feedback}";
+		if ( empty( $feedback ) ) {
+			wp_send_json_error( array( 'message' => __( 'フィードバックを入力してください。', 'jobmemory-ai' ) ) );
+		}
 
-        $memory = new JMAI_Memory();
-        $memory->append( $entry );
+		if ( ! in_array( $selected_pattern, self::ALLOWED_PATTERNS, true ) ) {
+			wp_send_json_error( array( 'message' => __( '無効なパターンが選択されました。', 'jobmemory-ai' ) ) );
+		}
 
-        wp_send_json_success( [ 'message' => 'フィードバックを保存しました。' ] );
-    }
+		$pattern_labels = array(
+			'a' => 'スタンダード',
+			'b' => '挑戦的',
+			'c' => 'カジュアル',
+		);
+		$label = $pattern_labels[ $selected_pattern ];
+		$date  = wp_date( 'Y-m-d H:i' );
 
-    /* ─── AJAX: Simple Job Boardに保存 ─── */
+		$entry = "\n[{$date}] 職種: {$job_title} / パターン: {$label}\nフィードバック: {$feedback}";
 
-    public function ajax_save_job(): void {
-        check_ajax_referer( 'jmai_nonce', 'nonce' );
+		$memory = new JMAI_Memory();
+		$memory->append( $entry );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => '権限がありません。' ] );
-        }
+		wp_send_json_success( array( 'message' => __( 'フィードバックを保存しました。', 'jobmemory-ai' ) ) );
+	}
 
-        $job_title        = sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) );
-        $content           = wp_kses_post( wp_unslash( $_POST['content'] ?? '' ) );
-        $selected_pattern = sanitize_text_field( wp_unslash( $_POST['selected_pattern'] ?? '' ) );
+	/* ─── AJAX: Simple Job Boardに保存 ─── */
 
-        if ( empty( $job_title ) || empty( $content ) ) {
-            wp_send_json_error( [ 'message' => '保存するデータがありません。' ] );
-        }
+	public function ajax_save_job(): void {
+		check_ajax_referer( 'jmai_nonce', 'nonce' );
 
-        if ( ! post_type_exists( 'jobpost' ) ) {
-            wp_send_json_error( [ 'message' => 'Simple Job Boardプラグインが有効になっていません。' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( '権限がありません。', 'jobmemory-ai' ) ) );
+		}
 
-        $post_id = wp_insert_post( [
-            'post_type'    => 'jobpost',
-            'post_title'   => $job_title,
-            'post_content' => $content,
-            'post_status'  => 'draft',
-        ] );
+		$job_title        = sanitize_text_field( wp_unslash( $_POST['job_title'] ?? '' ) );
+		$content          = wp_kses_post( wp_unslash( $_POST['content'] ?? '' ) );
+		$selected_pattern = sanitize_text_field( wp_unslash( $_POST['selected_pattern'] ?? '' ) );
 
-        if ( is_wp_error( $post_id ) ) {
-            wp_send_json_error( [ 'message' => '保存に失敗しました: ' . $post_id->get_error_message() ] );
-        }
+		if ( empty( $job_title ) || empty( $content ) ) {
+			wp_send_json_error( array( 'message' => __( '保存するデータがありません。', 'jobmemory-ai' ) ) );
+		}
 
-        wp_send_json_success( [
-            'message'  => '下書きとして保存しました。',
-            'post_id'  => $post_id,
-            'edit_url' => get_edit_post_link( $post_id, 'raw' ),
-        ] );
-    }
+		if ( ! in_array( $selected_pattern, self::ALLOWED_PATTERNS, true ) ) {
+			wp_send_json_error( array( 'message' => __( '無効なパターンが選択されました。', 'jobmemory-ai' ) ) );
+		}
 
-    /* ─── AJAX: Memoryリセット ─── */
+		if ( ! post_type_exists( 'jobpost' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Simple Job Boardプラグインが有効になっていません。', 'jobmemory-ai' ) ) );
+		}
 
-    public function ajax_reset_memory(): void {
-        check_ajax_referer( 'jmai_nonce', 'nonce' );
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'jobpost',
+				'post_title'   => $job_title,
+				'post_content' => $content,
+				'post_status'  => 'draft',
+			)
+		);
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => '権限がありません。' ] );
-        }
+		if ( is_wp_error( $post_id ) ) {
+			wp_send_json_error( array( 'message' => __( '保存に失敗しました: ', 'jobmemory-ai' ) . $post_id->get_error_message() ) );
+		}
 
-        $memory = new JMAI_Memory();
-        $memory->reset();
+		wp_send_json_success(
+			array(
+				'message'  => __( '下書きとして保存しました。', 'jobmemory-ai' ),
+				'post_id'  => $post_id,
+				'edit_url' => get_edit_post_link( $post_id, 'raw' ),
+			)
+		);
+	}
 
-        wp_send_json_success( [ 'message' => 'Memoryをリセットしました。' ] );
-    }
+	/* ─── AJAX: Memoryリセット ─── */
+
+	public function ajax_reset_memory(): void {
+		check_ajax_referer( 'jmai_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( '権限がありません。', 'jobmemory-ai' ) ) );
+		}
+
+		$memory = new JMAI_Memory();
+		$memory->reset();
+
+		wp_send_json_success( array( 'message' => __( 'Memoryをリセットしました。', 'jobmemory-ai' ) ) );
+	}
 }

--- a/jobmemory-ai/includes/class-memory.php
+++ b/jobmemory-ai/includes/class-memory.php
@@ -28,7 +28,7 @@ class JMAI_Memory {
     }
 
     public function init_default_memory(): bool {
-        if ( $this->get() !== '' ) {
+        if ( '' !== $this->get() ) {
             return false;
         }
 

--- a/jobmemory-ai/jobmemory-ai.php
+++ b/jobmemory-ai/jobmemory-ai.php
@@ -25,11 +25,20 @@ require_once JMAI_PLUGIN_DIR . 'includes/class-memory.php';
 require_once JMAI_PLUGIN_DIR . 'includes/class-ai-client.php';
 require_once JMAI_PLUGIN_DIR . 'includes/class-admin.php';
 
-register_activation_hook( __FILE__, function () {
-    $memory = new JMAI_Memory();
-    $memory->init_default_memory();
-} );
+register_activation_hook( __FILE__, 'jmai_activate' );
+add_action( 'plugins_loaded', 'jmai_init' );
 
-add_action( 'plugins_loaded', function () {
-    new JMAI_Admin();
-} );
+/**
+ * @return void
+ */
+function jmai_activate() {
+	$memory = new JMAI_Memory();
+	$memory->init_default_memory();
+}
+
+/**
+ * @return void
+ */
+function jmai_init() {
+	new JMAI_Admin();
+}


### PR DESCRIPTION
## Summary
- OpenAI APIキー保存時に `/v1/models` エンドポイントへテストリクエストを送信し、キーの有効性を検証するようにした
- 有効な場合：「登録成功」を青文字で表示し、キーを保存
- 無効な場合：「登録失敗」を赤文字で表示し、キーを保存しない

## Changes
- `class-ai-client.php`: `validate_api_key()` 静的メソッドを追加
- `class-admin.php`: 設定保存処理で `validate_api_key()` を呼び出し、結果に応じてメッセージを出し分け
- その他: CLAUDE.mdルール準拠のコーディング規約修正（配列構文・Yoda条件・i18n・クロージャ排除）

Closes #1

## Test plan
- [ ] 正しいAPIキーを入力して保存 → 「登録成功」が青文字で表示される
- [ ] 間違ったAPIキーを入力して保存 → 「登録失敗」が赤文字で表示される
- [ ] 間違ったキーで保存後、設定画面をリロード → 古いキー（または空）のまま
- [ ] 正しいキー保存後、求人生成が正常に動作する

Made with [Cursor](https://cursor.com)