### PR TITLE
fix: フィードバック送信時に選択パターンをAI再生成する (#3)

### DIFF
--- a/jobmemory-ai/assets/admin.css
+++ b/jobmemory-ai/assets/admin.css
@@ -116,6 +116,109 @@
     background: #f6f7f7;
 }
 
+/* AI Advice */
+.jmai-advice-content {
+    background: #f0f6fc;
+    border: 1px solid #c5d9ed;
+    border-radius: 4px;
+    padding: 16px 20px;
+    white-space: pre-wrap;
+    line-height: 1.8;
+    font-size: 14px;
+    color: #1d2327;
+}
+
+#jmai-advice-area h2 {
+    color: #2271b1;
+}
+
+/* Image upload */
+.jmai-images-preview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.jmai-image-item {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    overflow: hidden;
+    background: #f6f7f7;
+}
+
+.jmai-image-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.jmai-image-item .jmai-image-remove {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 22px;
+    height: 22px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 22px;
+    text-align: center;
+    padding: 0;
+    transition: background 0.15s;
+}
+
+.jmai-image-item .jmai-image-remove:hover {
+    background: #d63638;
+}
+
+.jmai-image-item .jmai-image-badge {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(34, 113, 177, 0.85);
+    color: #fff;
+    font-size: 10px;
+    text-align: center;
+    padding: 2px 0;
+}
+
+/* Loading button */
+.jmai-btn-loading {
+    position: relative;
+    pointer-events: none;
+    opacity: 0.7;
+}
+
+.jmai-btn-loading .jmai-btn-spinner {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(0, 0, 0, 0.2);
+    border-top-color: #50575e;
+    border-radius: 50%;
+    animation: jmai-spin 0.6s linear infinite;
+    vertical-align: middle;
+    margin-right: 6px;
+}
+
+.jmai-btn-loading.button-primary .jmai-btn-spinner {
+    border-color: rgba(255, 255, 255, 0.3);
+    border-top-color: #fff;
+}
+
+@keyframes jmai-spin {
+    to { transform: rotate(360deg); }
+}
+
 /* Notices in result area */
 #jmai-notices .notice {
     margin: 15px 0;


### PR DESCRIPTION
## Summary
- 「フィードバック（任意）」のラベルを「求人情報の指摘事項」に変更
- 指摘事項を送信すると、Memoryに保存した上で選択中のパターンをAIが再生成し、画面に即時反映するようにした
- 再生成完了後「求人文を再作成しました。」とメッセージを表示

## Changes
- `class-ai-client.php`: `regenerate_single()` メソッドを追加。現在の求人文+指摘事項+トーンを元にAIが1パターンだけ再生成
- `class-admin.php`: ラベルを「求人情報の指摘事項」に変更、ボタンを「指摘を送信して再作成」に変更、`ajax_save_feedback()` でMemory保存後にAI再生成を実行しレスポンスに含める
- `admin.js`: フィードバック送信時に現在のパターン内容も送信、レスポンスから再生成結果を取得して該当タブに反映

Closes #3

## Test plan
- [ ] 求人文生成後、指摘事項欄に改善点を入力して「指摘を送信して再作成」をクリック
- [ ] 選択中のパターンがAIで再生成され、タブ内容が更新される
- [ ] 「求人文を再作成しました。」とメッセージが表示される
- [ ] Memoryに指摘事項が保存されている（Memory確認画面で確認）
- [ ] 他のパターンのタブ内容は変更されていない

Made with [Cursor](https://cursor.com)