### PR TITLE
fix: 下書き保存成功時のメッセージが見えない問題を修正 (#4)

### DIFF
--- a/.claude/rules/rest-api.md
+++ b/.claude/rules/rest-api.md
@@ -1,0 +1,70 @@
+---
+paths:
+  - "includes/class-api.php"
+  - "src/api/**"
+---
+
+# REST API Rules
+
+## エンドポイント登録パターン
+
+```php
+add_action( 'rest_api_init', function() {
+    register_rest_route(
+        'myplugin/v1',
+        '/items',
+        array(
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+                'args'                => array(
+                    'per_page' => array(
+                        'type'              => 'integer',
+                        'default'           => 10,
+                        'sanitize_callback' => 'absint',
+                    ),
+                ),
+            ),
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'create_item' ),
+                'permission_callback' => array( $this, 'create_item_permissions_check' ),
+            ),
+        )
+    );
+} );
+```
+
+## 権限チェック
+
+```php
+// ❌ 本番では絶対に使わない
+'permission_callback' => '__return_true'
+
+// ✅ 必ず適切な権限チェックを実装
+public function get_items_permissions_check( WP_REST_Request $request ): bool {
+    return current_user_can( 'read' );
+}
+```
+
+## レスポンス形式
+
+```php
+// 成功
+return new WP_REST_Response( $data, 200 );
+
+// エラー
+return new WP_Error(
+    'myplugin_not_found',
+    __( 'Item not found.', 'myplugin' ),
+    array( 'status' => 404 )
+);
+```
+
+## ルール
+
+- ネームスペースは `myplugin/v1` で統一
+- `args` の `sanitize_callback` を必ず設定
+- `permission_callback` の `__return_true` は禁止（開発時のみ許可）
+- バージョンはURLパスに含める（`/v1/`）

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - "includes/**/*.php"
+  - "src/**/*.php"
+---
+
+# Security Rules (PHP)
+
+## Input Sanitization
+
+| 用途 | 使う関数 |
+|------|---------|
+| 一般テキスト | `sanitize_text_field()` |
+| メールアドレス | `sanitize_email()` |
+| URL（保存用） | `esc_url_raw()` |
+| 正の整数 | `absint()` |
+| 整数（負もあり） | `intval()` |
+| HTMLコンテンツ | `wp_kses_post()` |
+| スラッグ・キー | `sanitize_key()` |
+| ファイル名 | `sanitize_file_name()` |
+
+## Output Escaping
+
+| 用途 | 使う関数 |
+|------|---------|
+| HTML本文 | `esc_html()` |
+| HTML属性 | `esc_attr()` |
+| リンクURL | `esc_url()` |
+| JS変数 | `esc_js()` |
+| CSSプロパティ | `esc_attr()` |
+| 翻訳文字列 | `esc_html__()` / `esc_attr__()` |
+
+## Nonce Pattern
+
+```php
+// フォーム作成側
+wp_nonce_field( 'myplugin_{action}', 'myplugin_nonce' );
+
+// 処理側（必ずセットで実装する）
+if ( ! isset( $_POST['myplugin_nonce'] ) ||
+     ! wp_verify_nonce(
+         sanitize_text_field( wp_unslash( $_POST['myplugin_nonce'] ) ),
+         'myplugin_{action}'
+     )
+) {
+    wp_die( esc_html__( 'Security check failed.', 'myplugin' ) );
+}
+```
+
+## AJAX Pattern
+
+```php
+// JS側: nonce埋め込み
+wp_localize_script(
+    'myplugin-script',
+    'mypluginAjax',
+    array(
+        'nonce' => wp_create_nonce( 'myplugin_ajax' ),
+        'url'   => admin_url( 'admin-ajax.php' ),
+    )
+);
+
+// PHP側: ハンドラ
+add_action( 'wp_ajax_myplugin_action', 'myplugin_ajax_handler' );
+add_action( 'wp_ajax_nopriv_myplugin_action', 'myplugin_ajax_handler' );
+
+function myplugin_ajax_handler(): void {
+    check_ajax_referer( 'myplugin_ajax', 'nonce' );
+    if ( ! current_user_can( 'read' ) ) {
+        wp_send_json_error( array( 'message' => 'Permission denied.' ), 403 );
+    }
+    // 処理...
+    wp_send_json_success( $data );
+}
+```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,111 @@
+---
+paths:
+  - "tests/**/*.php"
+---
+
+# Testing Rules
+
+## TDDワークフロー（必ず守る）
+
+```
+1. 失敗するテストを先に書く（Red）
+2. テストをパスする最小限のコードを書く（Green）
+3. リファクタリングする（Refactor）
+```
+
+## テストクラスの雛形
+
+```php
+<?php
+/**
+ * Test class for [機能名].
+ *
+ * @package MyPlugin\Tests
+ */
+
+class Test_MyPlugin_Feature extends WP_UnitTestCase {
+
+    /**
+     * Set up each test.
+     */
+    public function set_up(): void {
+        parent::set_up();
+        // テスト前準備
+    }
+
+    /**
+     * Tear down each test.
+     */
+    public function tear_down(): void {
+        // テスト後クリーンアップ
+        parent::tear_down();
+    }
+
+    /**
+     * 正常系テスト例
+     */
+    public function test_returns_expected_value_on_valid_input(): void {
+        $result = myplugin_some_function( 'valid_input' );
+        $this->assertEquals( 'expected', $result );
+    }
+
+    /**
+     * 異常系テスト例
+     */
+    public function test_returns_false_on_invalid_input(): void {
+        $result = myplugin_some_function( '' );
+        $this->assertFalse( $result );
+    }
+
+    /**
+     * REST APIテスト例
+     */
+    public function test_rest_endpoint_returns_200_for_authenticated_user(): void {
+        wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+        $request  = new WP_REST_Request( 'GET', '/myplugin/v1/items' );
+        $response = rest_do_request( $request );
+        $this->assertEquals( 200, $response->get_status() );
+    }
+
+    /**
+     * セキュリティテスト例（未認証は401/403を返すか）
+     */
+    public function test_rest_endpoint_requires_auth(): void {
+        wp_set_current_user( 0 ); // 未認証
+        $request  = new WP_REST_Request( 'POST', '/myplugin/v1/items' );
+        $response = rest_do_request( $request );
+        $this->assertContains( $response->get_status(), array( 401, 403 ) );
+    }
+}
+```
+
+## テスト命名規則
+
+```
+test_{何を}_{どんな条件で}_{何が期待される}()
+
+例:
+test_save_settings_returns_true_on_valid_data()
+test_save_settings_returns_false_on_empty_input()
+test_rest_endpoint_returns_200_for_subscriber()
+```
+
+## テスト実行コマンド
+
+```bash
+# 特定ファイルのみ（推奨・高速）
+./vendor/bin/phpunit tests/test-settings.php
+
+# 特定メソッドのみ
+./vendor/bin/phpunit --filter test_save_settings_returns_true
+
+# 全テスト（CIのみ）
+composer run test
+```
+
+## ルール
+
+- テストファイル名: `test-{機能名}.php`
+- 1テストメソッド = 1アサーション（できるだけ）
+- セキュリティ機能（nonce/権限）には必ず異常系テストを書く
+- 全テストスイートはCIでのみ実行（ローカルは単体実行）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,227 @@
+# WordPress Plugin — Project Rules
+
+> このファイルはClaude Codeが**毎セッション冒頭に自動で読み込む**プロジェクトルールです。
+> 公式ドキュメント https://code.claude.com/docs/en/memory に準拠した構成です。
+
+---
+
+## Project Overview
+
+WordPressプラグイン開発プロジェクト。
+- **WordPress**: 6.4+
+- **PHP**: 8.1+
+- **JavaScript**: React + @wordpress/scripts（ES Modules）
+- **Coding Standard**: [WordPress Coding Standards (WPCS)](https://developer.wordpress.org/coding-standards/)
+
+詳細アーキテクチャ → @docs/architecture.md
+利用可能コマンド → @package.json / @composer.json
+
+---
+
+## Common Commands
+
+```bash
+# 開発サーバー起動
+npm run start
+
+# ビルド
+npm run build
+
+# PHPコーディング規約チェック
+composer run phpcs
+
+# PHP自動修正
+composer run phpcbf
+
+# PHPUnitテスト実行
+composer run test
+
+# 単一テストファイル実行（全体を回さない）
+./vendor/bin/phpunit tests/test-TARGET.php
+
+# JS型チェック
+npm run type-check
+
+# JSリント
+npm run lint:js
+```
+
+---
+
+## Workflow Rules
+
+- コードを変更したあとは必ず `composer run phpcs` でチェックする
+- テストは単体で実行する（全テストスイートは重いので避ける）
+- UIを変更した場合は変更前後のスクリーンショットを比較する
+- PRを出す前に `composer run test` と `npm run build` が通ることを確認する
+
+---
+
+## Branch Strategy
+
+```
+main     → 本番リリース済み（直接コミット禁止）
+develop  → 開発統合
+  └── feature/issue-{番号}-{機能名}
+  └── fix/issue-{番号}-{内容}
+  └── hotfix/issue-{番号}-{内容}
+```
+
+**コミットメッセージ形式:**
+
+```
+feat: 設定ページにダークモードを追加 (#12)
+fix: 保存ボタンが500エラーになる問題を修正 (#15)
+security: エスケープ漏れを修正 (#18)
+test: REST APIエンドポイントのテストを追加 (#20)
+```
+
+---
+
+## Security — MUST follow
+
+> ⚠️ セキュリティルールはすべてのコード生成で例外なく適用すること
+
+**入力（DB・処理に渡す前）は必ずサニタイズ:**
+```php
+sanitize_text_field()  // テキスト
+sanitize_email()       // メール
+esc_url_raw()          // URL（保存時）
+absint()               // 正の整数
+wp_kses_post()         // HTML許可コンテンツ
+```
+
+**出力（HTML表示前）は必ずエスケープ:**
+```php
+esc_html()   // 本文テキスト
+esc_attr()   // 属性値
+esc_url()    // リンクURL
+esc_js()     // JS内変数
+```
+
+**フォーム・AJAX処理では必ずNonce検証:**
+```php
+// フォーム
+wp_nonce_field( 'myplugin_action', 'myplugin_nonce' );
+wp_verify_nonce( $_POST['myplugin_nonce'], 'myplugin_action' );
+
+// AJAX
+check_ajax_referer( 'myplugin_ajax', 'nonce' );
+```
+
+**権限チェックを必ず実施:**
+```php
+current_user_can( 'manage_options' )  // 管理者機能
+current_user_can( 'edit_post', $id )  // 投稿編集
+```
+
+**DB操作は必ず `$wpdb->prepare()` を使う:**
+```php
+$wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}table WHERE id = %d", $id ) );
+```
+
+---
+
+## PHP Coding Standards
+
+```php
+// 命名: スネークケース（関数・変数・フック）
+function myplugin_get_settings() {}
+add_action( 'myplugin_after_save', 'callback' );
+
+// 命名: アッパーキャメル（クラス）
+class MyPlugin_Admin {}
+
+// 命名: 全大文字（定数）
+define( 'MYPLUGIN_VERSION', '1.0.0' );
+
+// インデント: タブ（スペース不可）
+// 制御構造の括弧内にスペース
+if ( true === $flag ) {}
+
+// Yoda条件（定数・リテラルを左辺に）
+if ( 'publish' === $post->post_status ) {}
+
+// 配列: long syntax
+$args = array( 'key' => 'value' );  // [] は使わない
+
+// die()ではなく wp_die() を使う
+wp_die( esc_html__( 'Error', 'myplugin' ) );
+```
+
+---
+
+## Internationalization (i18n)
+
+すべての表示文字列をi18n関数でラップすること:
+
+```php
+__( 'Text', 'myplugin' )          // 文字列返却
+_e( 'Text', 'myplugin' )          // 直接出力
+_n( '%d item', '%d items', $n, 'myplugin' )  // 複数形
+esc_html__( 'Text', 'myplugin' )  // エスケープ付き返却
+esc_html_e( 'Text', 'myplugin' )  // エスケープ付き出力
+```
+
+---
+
+## DO NOT (禁止操作)
+
+- `main` / `master` ブランチへの直接コミット
+- `$wpdb->query()` での未prepareなSQL実行
+- `eval()` / `extract()` / `shell_exec()` / バッククォート演算子
+- `@` エラー制御演算子
+- ショートタグ `<?=` の使用（必ず `<?php echo` ）
+- `die()` / `exit()` の直接呼び出し（`wp_die()` を使う）
+- Nonce・権限チェックなしのフォーム・AJAX処理
+- `add_action()` / `add_filter()` へのクロージャ直接渡し（`remove_action` できなくなる）
+- APIキー・パスワード等のフロントエンド（JS/HTML）への露出
+
+---
+
+## Directory Structure
+
+```
+my-plugin/
+├── my-plugin.php          # メインファイル（ヘッダー・初期化）
+├── uninstall.php          # アンインストール処理
+├── composer.json
+├── package.json
+├── includes/
+│   ├── class-plugin.php   # コアクラス（シングルトン）
+│   ├── class-admin.php
+│   ├── class-api.php      # REST API
+│   └── class-db.php
+├── src/                   # JSソース（ビルド前）
+├── build/                 # ビルド済みJS/CSS
+├── languages/
+└── tests/
+    ├── bootstrap.php
+    └── test-*.php
+```
+
+---
+
+## TDD Workflow
+
+```
+1. テストを先に書く（Red）
+2. Claude Codeにテストをパスするコードを書かせる（Green）
+3. リファクタリング（Refactor）
+```
+
+**単一テスト実行例:**
+```bash
+./vendor/bin/phpunit tests/test-api.php --filter test_endpoint_returns_200
+```
+
+---
+
+## Modular Rules
+
+詳細ルールはトピック別ファイルで管理（自動ロード）:
+
+- セキュリティ詳細 → @.claude/rules/security.md
+- REST API規約 → @.claude/rules/rest-api.md
+- テスト規約 → @.claude/rules/testing.md
+- GitHub Actionsワークフロー → @.github/workflows/ci.yml

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/jobmemory-ai/assets/admin.js
+++ b/jobmemory-ai/assets/admin.js
@@ -192,6 +192,9 @@ jQuery(document).ready(function ($) {
         var cssClass = type === 'success' ? 'notice-success' : 'notice-error';
         var html = '<div class="notice ' + cssClass + ' is-dismissible"><p>' + message + '</p></div>';
         $('#jmai-notices').html(html);
+        $('html, body').animate({
+            scrollTop: $('#jmai-notices').offset().top - 100
+        }, 300);
     }
 
     function clearNotices() {

--- a/jobmemory-ai/includes/class-admin.php
+++ b/jobmemory-ai/includes/class-admin.php
@@ -173,10 +173,10 @@ class JMAI_Admin {
                         <button type="button" class="button" id="jmai-save-feedback-btn">フィードバックを保存</button>
                         <button type="button" class="button button-primary" id="jmai-save-job-btn">Simple Job Boardに下書き保存</button>
                     </div>
+
+                    <div id="jmai-notices"></div>
                 </div>
             </div>
-
-            <div id="jmai-notices"></div>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- 下書き保存成功時のメッセージ（「下書きとして保存しました。」）がユーザーに見えない問題を修正
- 通知エリア `#jmai-notices` がページ最下部にあり、ボタン操作後の画面位置から離れていたのが原因

## Changes
- `class-admin.php`: `#jmai-notices` をボタン直下（カード内）に移動し、操作結果がすぐ目に入る位置に配置
- `admin.js`: `showNotice()` でメッセージ表示後に通知エリアへ自動スクロールするようにした

Closes #4

## Test plan
- [ ] 求人文生成後、「Simple Job Boardに下書き保存」をクリック
- [ ] 「下書きとして保存しました。」メッセージがボタン直下に表示される
- [ ] メッセージ位置へ自動スクロールされ、確実に視認できる
- [ ] 「編集画面を開く」リンクも正常に表示される
- [ ] エラー時のメッセージも同様に見える位置に表示される

Made with [Cursor](https://cursor.com)