### PR TITLE
feat: 会社HPから情報を自動取得する機能を追加

### DIFF
--- a/jobmemory-ai/assets/admin.css
+++ b/jobmemory-ai/assets/admin.css
@@ -29,6 +29,48 @@
     font-weight: bold;
 }
 
+/* HP fetch section */
+.jmai-hp-input-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.jmai-hp-input-row input[type="url"] {
+    flex: 1;
+    max-width: 400px;
+}
+
+.jmai-hp-input-row .spinner {
+    float: none;
+    margin: 0;
+}
+
+.jmai-message {
+    margin-top: 10px;
+    padding: 8px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+    white-space: pre-line;
+}
+
+.jmai-message.success {
+    background: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.jmai-message.error {
+    background: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+.jmai-message:empty {
+    display: none;
+}
+
 /* Loading */
 .jmai-loading-spinner {
     display: flex;


### PR DESCRIPTION
## Summary

- 会社HPのURLを入力して「情報を取得」ボタンを押すと、AIがWebページを解析し、会社の強み・事業内容・職場環境を自動で入力欄に反映する機能を追加
- 「事業内容」フィールドを新規追加し、求人生成プロンプトにも反映
- HP取得は任意機能で、使わなくても従来通り求人生成可能

## Changes

### PHP (class-admin.php)
- `ajax_fetch_company_info` AJAXハンドラ追加（nonce検証・権限チェック済み）
- `fetch_webpage` - `wp_remote_get`でHTMLを取得
- `extract_text_from_html` - script/style/nav/footerを除去してテキスト抽出（最大5000文字）
- HP取得セクションUI + 事業内容フィールドをフォームに追加

### PHP (class-ai-client.php)
- `extract_company_info` メソッド追加 - OpenAI APIでWebページテキストからJSON形式で企業情報を抽出
- `build_prompt`に事業内容パラメータを追加

### JS (admin.js)
- HP取得ボタンのクリックイベント（URLバリデーション・ローディング表示・自動入力）
- 求人生成AJAXに`business_description`を追加

### CSS (admin.css)
- HP取得セクション・メッセージ表示のスタイル

## Test plan
- [ ] URL未入力で「情報を取得」→ エラーメッセージ表示
- [ ] 無効なURL入力 → エラーメッセージ表示
- [ ] 存在しないURL → エラーメッセージ表示
- [ ] 会社概要ページのURL入力 → 情報取得成功 → 入力欄に自動反映
- [ ] HP取得後に手動で編集可能
- [ ] HP取得なしで従来通り求人生成可能
- [ ] 事業内容が求人文に反映される

Closes #7

Made with [Cursor](https://cursor.com)